### PR TITLE
2022/12/22 backend edit

### DIFF
--- a/src/main/java/NoJobs/BePro/Controller/MemberController.java
+++ b/src/main/java/NoJobs/BePro/Controller/MemberController.java
@@ -122,45 +122,44 @@ public class MemberController {
 
     @PostMapping("/auth")
     public Map AuthSwitch(@RequestBody AuthForm form){
+        /*System.out.println("------------------");
+        System.out.println(form.getId());
+        System.out.println(form.getIndex());
+        System.out.println(form.getToken());
+        System.out.println(form.getIsAdmin());
+        System.out.println(form.getIsEdit());
+        System.out.println(form.getIsLogin());
+        System.out.println("------------------");*/
         Map<String,Object> result = new HashMap();
-        if(form.getEdit()){
+
+        if(form.getIsEdit()!=null){
             if(memberService.isEditer(form.getId(),form.getIndex())){
-                result.put("auth",true);
-                result.put("msg","인증되었습니다");
-                return result;
+                result.put("editAuth",true);
+            }else {
+                result.put("editAuth", false);
             }
-            result.put("auth",false);
-            result.put("msg","권한이 없습니다");
-            return result;
-        }else if(form.getLogin()){
-            result.put("auth",false);
-            result.put("msg","권한이 없습니다");
+        }
+        if(form.getIsSignin()!=null){
             Member member = memberService.findOne(form.getId()).get();
-            if(!member.getToken().isEmpty()){
-                if(member.getToken()==form.getToken()){
-                    result.put("auth",true);
-                    result.put("msg","인증되었습니다");
-                    return result;
-                }
+            if(!member.getToken().isEmpty() && member.getToken().equals(form.getToken())){
+                result.put("signinAuth",true);
+            }else{
+                result.put("signinAuth",false);
             }
-            return result;
-        }else if(form.getAdmin()){
+        }
+        if(form.getIsAdmin()!=null){
             Member member = memberService.findOne(form.getId()).get();
             if(member.getAdmin()==1){
-                result.put("auth",true);
-                result.put("msg","인증되었습니다");
-                return result;
+                result.put("adminAuth",true);
+
+            }else{
+                result.put("adminAuth",false);
             }
-            result.put("auth",false);
-            result.put("msg","권한이 없습니다");
-            return  result;
         }
-        result.put("auth",false);
-        result.put("msg","권한이 없습니다");
         return result;
     }
 
-    @PostMapping("/mypage/userupdate")
+    @PostMapping("/user/userupdate")
     public Map updateMember(@RequestBody MemberForm form){
         Map result = new HashMap<String, Object>();
         if(memberService.updateMemberInfo(form)){

--- a/src/main/java/NoJobs/BePro/Controller/PostController.java
+++ b/src/main/java/NoJobs/BePro/Controller/PostController.java
@@ -44,34 +44,34 @@ public class PostController {
     }
 
 
-    @PostMapping("/qna/post")
+    @PostMapping("/post/qna")
     public Map postQna(@RequestBody PostForm form){
         return postService.post(form,"qna");
     }
 
-    @PostMapping("/notice/post")
+    @PostMapping("/post/notice")
     public Map postNotice(@RequestBody PostForm form){
         return postService.post(form,"notice");
     }
 
-    @PostMapping("/qna/update")
+    @PostMapping("/update/qna")
     public Map updateQna(@RequestBody PostForm form){
         return postService.update(form,"qna");
     }
 
-    @PostMapping("/notice/update")
+    @PostMapping("/update/notice")
     public Map updateNotice(@RequestBody PostForm form){
         return postService.update(form,"notice");
     }
 
-    @PostMapping("/mypage/getpostings")
+    @PostMapping("/user/getpostings")
     public List<Map> findMemberPost(@RequestBody MemberForm form){
         return postService.getOnesPost(form.getId());
     }
 
     @PostMapping("/board/view")
     public Map findById(@RequestBody PostForm form){
-        return postService.getPostById(form.getId());
+        return postService.getPostById(form.getId(),form.getBoard());
     }
 
 }

--- a/src/main/java/NoJobs/BePro/Form/AuthForm.java
+++ b/src/main/java/NoJobs/BePro/Form/AuthForm.java
@@ -5,7 +5,7 @@ public class AuthForm {
     private int index;
     private String token;
     private Boolean isEdit;
-    private Boolean isLogin;
+    private Boolean isSignin;
     private Boolean isAdmin;
 
     public String getId() {
@@ -32,27 +32,23 @@ public class AuthForm {
         this.token = token;
     }
 
-    public Boolean getEdit() {
+    public Boolean getIsEdit() {
         return isEdit;
     }
 
-    public void setEdit(Boolean edit) {
+    public void setIsEdit(Boolean edit) {
         isEdit = edit;
     }
 
-    public Boolean getLogin() {
-        return isLogin;
+    public Boolean getIsSignin() {
+        return isSignin;
     }
 
-    public void setLogin(Boolean login) {
-        isLogin = login;
+    public void setIsSignin(Boolean signin) {
+        isSignin = signin;
     }
 
-    public Boolean getAdmin() {
-        return isAdmin;
-    }
+    public Boolean getIsAdmin() { return isAdmin; }
 
-    public void setAdmin(Boolean admin) {
-        isAdmin = admin;
-    }
+    public void setIsAdmin(Boolean admin) { isAdmin = admin; }
 }

--- a/src/main/java/NoJobs/BePro/Form/PostForm.java
+++ b/src/main/java/NoJobs/BePro/Form/PostForm.java
@@ -7,6 +7,8 @@ public class PostForm {
     String uploaderId;
     String id;
 
+    String board;
+
     public String getTitle() {
         return title;
     }
@@ -38,6 +40,10 @@ public class PostForm {
     public void setUploaderId(String uploaderId) {
         this.uploaderId = uploaderId;
     }
+
+    public void setBoard(String board) { this.board = board; }
+
+    public String getBoard() { return board; }
 
     public String getId() {
         return id;

--- a/src/main/java/NoJobs/BePro/Repository/JdbcMemberRepository.java
+++ b/src/main/java/NoJobs/BePro/Repository/JdbcMemberRepository.java
@@ -16,7 +16,7 @@ public class JdbcMemberRepository implements MemberRepository {
     }
     @Override
     public Member save(Member member) {
-        String sql = "insert into member(member_id, member_password, member_email, member_nickname, member_major, member_isPro) values(?,?,?,?,?)";
+        String sql = "insert into member(member_id, member_password, member_email, member_nickname, member_major, member_isPro) values(?,?,?,?,?,?)";
         Connection conn = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;

--- a/src/main/java/NoJobs/BePro/Repository/JdbcPostRepository.java
+++ b/src/main/java/NoJobs/BePro/Repository/JdbcPostRepository.java
@@ -22,9 +22,9 @@ public class JdbcPostRepository implements PostRepository {
     }
 
     @Override
-    public Map findByPostId(Long id) {
+    public Map findByPostId(Long id,String board) {
         Map<String, Object> reslut = new HashMap<>();
-        String sql = "SELECT * FROM post LEFT JOIN member ON post.post_uploader = member.member_idnum WHERE post_id = ?";
+        String sql = "SELECT * FROM post LEFT JOIN member ON post.post_uploader = member.member_idnum WHERE post_id = ? AND post.post_category = ?";
         Connection conn = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
@@ -32,11 +32,13 @@ public class JdbcPostRepository implements PostRepository {
             conn = getConnection();
             pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
+            pstmt.setString(2, board);
             rs = pstmt.executeQuery();
             if(rs.next()) {
                 reslut.put("title", rs.getString("post_title"));
                 reslut.put("id", rs.getString("post_id"));
                 reslut.put("uploaderNick", rs.getString("member_nickname"));
+                reslut.put("uploaderId",rs.getString("member_id"));
                 reslut.put("view", rs.getString("post_view"));
                 reslut.put("uploadtime", rs.getString("post_uploadtime"));
                 reslut.put("like", rs.getString("post_like"));

--- a/src/main/java/NoJobs/BePro/Repository/PostRepository.java
+++ b/src/main/java/NoJobs/BePro/Repository/PostRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface PostRepository {
     Post save(Post post);
-    Map findByPostId(Long id);
+    Map findByPostId(Long id, String board);
     Optional<Post> findBytitle(String title);
     List<Post> findBytitleAndTag(String title,String[] tags);
     List<Post> findAll();

--- a/src/main/java/NoJobs/BePro/Service/PostService.java
+++ b/src/main/java/NoJobs/BePro/Service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
         return postRepository.findByMember(id);
     }
 
-    public Map getPostById(String id) {
-        return postRepository.findByPostId(Long.parseLong(id));
+    public Map getPostById(String id, String board) {
+        return postRepository.findByPostId(Long.parseLong(id),board);
     }
 }


### PR DESCRIPTION
postForm Edit & auth system implement

1. url 수정

proxy 설정을 따로 모듈다운해서 처리하다보니
url이 겹치면 이새기가 무조건 404를 띄워버리더라고
ex) localhost:3000/qna/1 : 백엔드에서 id값 통해서 글 받아오기
여기서 localhost:3000/qna/update : 백엔드에 글 업데이트 시키기
위의 두 개 url의 시작점이 qna로 겹치니까 목적에 안맞는 행동을 하거나 404를 띄워버림
따라서 화이트리스트를 세분화 할 빠엔 url 겹치는 부분을 최대한 없앰

2. board 받아오기
/board/view : 게시판종류와 고유 인덱스번호를 받아서 글 상세정보 뿌려주는 url
여기서 게시판 종류 받아오는 부분이 없길래 form이랑 수정해서 
게시판 종류 백에서 받아올 수 있도록 수정함.

3. 인증시스템 변경

기존의 너가 구현한 인증시스템은 isEdit, isLogin, isAdmin을 각각 처리하는것 같에서
if문 수정을 통해서 isEdit:true, isLogin:true, isAdmin:false 이런식으로 넘어와도
한번에 처리 되어서 return값을 보내도록 수정함

return값도 이전에는 auth : true면 통과 false면 불통이었는데
통과 되고말고는 프론트에서 결정하고 authEdit:true or false, authLogin:true or false와 같이
변경함

위의 부분은 아직 체크처리 안한이유가

나중에 댓글 수정 기능에서도 좀 더 수정사항이 생길 수 있기 때문에 아직

체크 처리는 안해놓음


4. 쿼리문 잔 버그 고침