### PR TITLE
2023/01/03 request

### DIFF
--- a/src/main/java/NoJobs/BePro/Controller/PostController.java
+++ b/src/main/java/NoJobs/BePro/Controller/PostController.java
@@ -20,8 +20,9 @@ public class PostController {
         this.postService = postService;
     }
 
-    @PostMapping("/search")
+    @PostMapping("/post/searchquery")
     public List<Post> searchEveryHashtag(@RequestBody SearchForm form){
+
         return postService.searchByTitleAndTag(form.getInputValue(), form.getHashTags());
     }
     @PostMapping("/board/main")

--- a/src/main/java/NoJobs/BePro/Repository/JdbcPostRepository.java
+++ b/src/main/java/NoJobs/BePro/Repository/JdbcPostRepository.java
@@ -62,7 +62,6 @@ public class JdbcPostRepository implements PostRepository {
 
     @Override
     public List<Post> findBytitleAndTag(String title, String[] tags) {
-
         if (tags.length == 0) {
             String sql = "SELECT * FROM post LEFT JOIN member ON post.post_uploader = member.member_idnum WHERE post.post_title LIKE ?";
             Connection conn = null;
@@ -321,9 +320,9 @@ public class JdbcPostRepository implements PostRepository {
     @Override
     public void updatePost(PostForm form, String category) {
         MemberRepository memberRepository = new JdbcMemberRepository(dataSource);
-        Member uploader = memberRepository.findById(form.getUploaderId()).get();
+        //Member uploader = memberRepository.findById(form.getUploaderId()).get();
 
-        String sql = "UPDATE post SET post_title = ?, post_uploader = ?, post_detail = ?, post_category = ? WHERE post_id = ?";
+        String sql = "UPDATE post SET post_title = ?, post_detail = ?, post_category = ? WHERE post_id = ?";
         Connection conn = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
@@ -332,10 +331,9 @@ public class JdbcPostRepository implements PostRepository {
             pstmt = conn.prepareStatement(sql,
                     Statement.RETURN_GENERATED_KEYS);
             pstmt.setString(1, form.getTitle());
-            pstmt.setLong(2, uploader.getIdNum());
-            pstmt.setString(3, form.getDetail());
-            pstmt.setString(4, category);
-            pstmt.setString(5, form.getId());
+            pstmt.setString(2, form.getDetail());
+            pstmt.setString(3, category);
+            pstmt.setString(4, form.getId());
             pstmt.execute();
             rs = pstmt.getGeneratedKeys();
 


### PR DESCRIPTION
1. 게시글 업데이트 쿼리문 변경
 - 어드민 권한 계정의 경우 모든 게시글과 댓글 수정권한이 생기는데, 이 때 게시글 변경 시 어드민 계정 아이디가 남는 문제 발생
 - DB에 게시글 데이터 업데이트 시 작성자는 변경하지 않는 걸로 수정
 - 본인 제외하면 일반적인 상황에선 변경할 일 없다고 판단
2. 검색api /search -> /post/searchquery로 api 명 변경
 - 이건 Router 명이랑 api명이랑 같아서 whitelabel 에러가 뜨는데, 문제 해결을 위해 프론트 라우팅 아니면 api명을 바꿔야 한다.
 - 그냥 api명 바꾸는걸 택함
 - 프록시 화이트리스트를 /post/*로 묶는게 낫겠더라고